### PR TITLE
create service account, roles and rolebindings for *PostDeploy: ConfigMap info in MD Format (10)

### DIFF
--- a/rbac/postdeploy-output-info/rb.yaml
+++ b/rbac/postdeploy-output-info/rb.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postdeploy-output-info-rb-cp4ba
+  namespace: cp4ba
+subjects:
+- kind: ServiceAccount
+  name: postdeploy-output-info-sa
+  namespace: output-info
+roleRef:
+  kind: Role
+  name: postdeploy-cp4ba-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: postdeploy-output-info-rb-output-info
+  namespace: output-info
+subjects:
+- kind: ServiceAccount
+  name: postdeploy-output-info-sa
+  namespace: output-info
+roleRef:
+  kind: Role
+  name: postdeploy-output-info-role
+  apiGroup: rbac.authorization.k8s.io

--- a/rbac/postdeploy-output-info/role.yaml
+++ b/rbac/postdeploy-output-info/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: postdeploy-cp4ba-reader
+  namespace: cp4ba
+rules:
+- apiGroups: ["","icp4a.ibm.com"]
+  resources: ["*"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: postdeploy-output-info-role
+  namespace: output-info
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["get","create","delete","patch"]

--- a/rbac/postdeploy-output-info/role.yaml
+++ b/rbac/postdeploy-output-info/role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cp4ba
 rules:
 - apiGroups: ["","icp4a.ibm.com"]
-  resources: ["*"]
+  resources: ["icp4aclusters"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,5 +15,5 @@ metadata:
   namespace: output-info
 rules:
 - apiGroups: [""]
-  resources: ["*"]
+  resources: ["configmaps"]
   verbs: ["get","create","delete","patch"]

--- a/rbac/postdeploy-output-info/sa.yaml
+++ b/rbac/postdeploy-output-info/sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postdeploy-output-info-sa
+  namespace: output-info
+automountServiceAccountToken: true


### PR DESCRIPTION
For this task, the service account authorizes just the required steps to 
* query the ICP4ACluster in the cp4ba namespace for the optional components and deployment patterns
* create a ConfigMap in the output-info namespace, 
* in case the ConfigMap exists, delete it to allow a new ConfigMap to be written,
* but prior to deletion, patch it to remove the finalizers that prevent deletion otherwise

Access to the ICP4ACluster requires the *icp4a.ibm.com* API Group.